### PR TITLE
Expose `useGAAuth` to typescript consumers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,6 @@ export { GATracker } from './core/GATracker';
 export { GAProvider, useAnalytics } from './react/context/GAProvider';
 export { useGoogleAnalytics } from './react/hooks/useGoogleAnalytics';
 export { useGAEcommerce } from './react/hooks/useGAEcommerce';
-export { useGAEcommerce } from './react/hooks/useGAEcommerce';
 export { useGAAuth } from './react/hooks/useGAAuth';
 
 // types

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,8 @@ export { GATracker } from './core/GATracker';
 export { GAProvider, useAnalytics } from './react/context/GAProvider';
 export { useGoogleAnalytics } from './react/hooks/useGoogleAnalytics';
 export { useGAEcommerce } from './react/hooks/useGAEcommerce';
+export { useGAEcommerce } from './react/hooks/useGAEcommerce';
+export { useGAAuth } from './react/hooks/useGAAuth';
 
 // types
 export * from './types/analytics';


### PR DESCRIPTION
## 🌎 Purpose
Expose `useGAAuth` to typescript consumers.

For anyone else running into this error, a workaround until this change is vended is to use

```
import { useAnalytics } from '@connectaryal/google-analytics'

...

// inside of GAProvider
const { trackLogin, trackSignUp } = useAnalytics()
```